### PR TITLE
apparently blank messages can come in?

### DIFF
--- a/src/main/scala/examples.sc
+++ b/src/main/scala/examples.sc
@@ -53,7 +53,9 @@ val Pattern = """[@]dvbt (.+)""".r
   case Pattern(test) => s"matches: $test"
   case _ => "doesn't match"
 }
+// MessageReceived(C0D0QE69K,U03P7GUMN,@dbvt has some sass)
 val myUserId = "U0K3W1BK3"
+val myUserName = "dvbt"
 val Mine = s""".*[<][@]$myUserId[>][: ]+(.+)""".r
 "<@U0K3W1BK3>: do some stuff" match {
   case Mine(message) => s"matched: $message"


### PR DESCRIPTION
deleted messages also come through as type `message`:

```
2016-02-10 10:58:18:887 [default-akka.actor.default-dispatcher-4] DEBUG slack.SlackChatActor - {"channel":"C0D0QE69K","subtype":"message_deleted","ts":"1455119898.001066","previous_message":{"type":"message","user":"U03P7GUMN","text":"@dbvt has some sass","ts":"1455119852.001062"},"hidden":true,"deleted_ts":"1455119852.001062","event_ts":"1455119898.759463","type":"message"}
```

```
2016-02-10 10:58:18:896 [default-akka.actor.default-dispatcher-4] ERROR akka.actor.OneForOneStrategy - Object is missing required member 'text'
spray.json.DeserializationException: Object is missing required member 'text'
    at spray.json.package$.deserializationError(package.scala:23)
    at spray.json.ProductFormats$class.fromField(ProductFormats.scala:60)
    at slack.SlackRTProtocol$.fromField(SlackChatActor.scala:10)
    at spray.json.ProductFormatsInstances$$anon$4.read(ProductFormatsInstances.scala:105)
    at spray.json.ProductFormatsInstances$$anon$4.read(ProductFormatsInstances.scala:92)
    at spray.json.JsValue.convertTo(JsValue.scala:31)
    at slack.SlackChatActor$$anonfun$connected$1.applyOrElse(SlackChatActor.scala:33)
    at akka.actor.Actor$class.aroundReceive(Actor.scala:467)
    at slack.SlackChatActor.aroundReceive(SlackChatActor.scala:23)
    at akka.actor.ActorCell.receiveMessage(ActorCell.scala:516)
    at akka.actor.ActorCell.invoke(ActorCell.scala:487)
    at akka.dispatch.Mailbox.processMailbox(Mailbox.scala:238)
    at akka.dispatch.Mailbox.run(Mailbox.scala:220)
    at akka.dispatch.ForkJoinExecutorConfigurator$AkkaForkJoinTask.exec(AbstractDispatcher.scala:397)
    at scala.concurrent.forkjoin.ForkJoinTask.doExec(ForkJoinTask.java:260)
    at scala.concurrent.forkjoin.ForkJoinPool$WorkQueue.runTask(ForkJoinPool.java:1339)
    at scala.concurrent.forkjoin.ForkJoinPool.runWorker(ForkJoinPool.java:1979)
    at scala.concurrent.forkjoin.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:107)
Caused by: java.util.NoSuchElementException: key not found: text
    at scala.collection.MapLike$class.default(MapLike.scala:228)
    at scala.collection.AbstractMap.default(Map.scala:59)
    at scala.collection.MapLike$class.apply(MapLike.scala:141)
    at scala.collection.AbstractMap.apply(Map.scala:59)
    at spray.json.ProductFormats$class.fromField(ProductFormats.scala:57)
    ... 16 more
```
